### PR TITLE
Make coqsplit build with -safe-string

### DIFF
--- a/coqsplit.ml
+++ b/coqsplit.ml
@@ -422,7 +422,7 @@ let sanity_check s =
 
 let main () =
   let s = readchan stdin in
-  let s1 = apply_spec silent_spec s in
+  let s1 = apply_spec silent_spec (Bytes.to_string s) in
   let s2 =
     if exerciselist then
       (* If exerciselist is on, we will only parse the exercises *)


### PR DESCRIPTION
OCaml 4.06.0 (November 2017) made -safe-string the default. Without this
change, building coqsplit with a newer ocamlc fails with

Error: This expression has type bytes but an expression was expected of type
         string

regarding the second argument to apply_spec in main's definition of s1.

The Bytes module along with the -safe-string and -unsafe-string options
were introduced with OCaml 4.02.0 (August 2014).